### PR TITLE
Render no iframe update

### DIFF
--- a/src/APIRequests/renderer.ts
+++ b/src/APIRequests/renderer.ts
@@ -1,0 +1,28 @@
+// this should more than likely be redirected at the backend rather
+// than the renderer, unless we're going to go with the JWE route
+import axios from 'axios';
+import type { RendererResponse } from 'src/typings/renderer';
+
+export async function fetchProblem(formData: FormData, url: string, overrides: {[k:string]: string}) {
+	Object.keys(overrides).forEach((k)=>{
+		formData.set(k, overrides[k]);
+	});
+
+	let renderedHTML = '';
+	let js: Array<string> = [];
+	let css: Array<string> = [];
+	try {
+		const response = await axios.post(url, formData,
+			{ headers: { 'Content-Type': 'multipart/form-data' } });
+
+		const data = response.data as RendererResponse;
+
+		renderedHTML = data.renderedHTML;
+		js = data.resources.js;
+		css = data.resources.css;
+	} catch(e) {
+		renderedHTML = (e as Error).message;
+	}
+
+	return { renderedHTML, js, css };
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const RENDER_URL = '/renderer/render-api';


### PR DESCRIPTION
Similar to my update in the iframe branch, add listeners to interrupt form submission, capture the response and update the div. Test this out, there are still some console errors after submitting a response to a problem.

I will work next on updating the renderer for ww3 format -- getting the response table out of the renderedHTML. Any other requests for splitting things out?