### PR TITLE
Doc and test lodash replacement

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -33,7 +33,15 @@ export const pick = <T>(object: { [key: string]: T }, keys: Array<string>): { [k
  * const obj = { a: 1, b: 2, c: 3, d: 4 };
  * mapValues(obj, (x: number) => x + 1) returns { a: 2, b: 3, c: 4, d: 5 }
  *
- *
+ * This can include nested objects:
+ * const obj2 = {
+ *    apples: { category: 'produce', quantity: 3 },
+ *    hot_dots: { category: 'deli', quantity: 5 },
+ *    ice_cream: { category: 'frozen', quantity: 10 }
+ * };
+ * mapValues(obj2, food => food.category))
+ * returns
+ * { apples: 'produce', hot_dogs: 'deli', ice_cream: 'frozen' }
  */
 
 export const mapValues = <T, S>(object: { [key: string]: T }, mapper: (key: T) => S): { [key: string]: S} => {
@@ -49,7 +57,9 @@ export const mapValues = <T, S>(object: { [key: string]: T }, mapper: (key: T) =
  * @param object Object of the form: { [key: string]: string }
  * @returns the object where the key and value has been swapped.
  *
- *
+ *  invert({ a: '1', b: '2', c: '3', d: '4' })
+ *  returns
+ *  {'1': 'a', '2': 'b', '3': 'c', '4': 'd'}
  */
 
 export const invert = (object: { [key: string]: string }) => {
@@ -74,7 +84,17 @@ export const pickBy = <T>(object: { [key: string]: T }, check: (value: T) => boo
 	return obj;
 };
 
-export const random = (max: number, min: number) => {
+/**
+ * This returns a random integer between ceil(min) and floor(max).
+ *
+ * @param max a number
+ * @param min
+ * @returns a random integer between ceil(min) and floor(max).
+ *
+ * For example, random(5,10) returns one of 5,6,7,8,9
+ */
+
+export const random = (min: number, max: number) => {
 	min = Math.ceil(min);
 	max = Math.floor(max);
 	return Math.floor(Math.random() * (max - min) + min);

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -84,6 +84,16 @@ export const pickBy = <T>(object: { [key: string]: T }, check: (value: T) => boo
 	return obj;
 };
 
+/**
+ * This returns a random integer between ceil(min) and floor(max).
+ *
+ * @param max a number
+ * @param min
+ * @returns a random integer between ceil(min) and floor(max).
+ *
+ * For example, random(5,10) returns one of 5,6,7,8,9
+ */
+
 export const random = (min: number, max: number) => {
 	min = Math.ceil(min);
 	max = Math.floor(max);

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,3 +1,19 @@
+// These are a set of functions to replace equivalents in lodash.
+
+/**
+ * This returns an object formed by the passed in object and only the selected
+ * keys.
+ *
+ *
+ * @param object: An object in the form { [key: string]: T }
+ * @param keys: The keys of the object to be returned as an array of strings.
+ * @returns an object with only those selected keys.
+ *
+ * Example:
+ *
+ * const obj = {a: 1, b: 2, c: 3, d: 4}
+ * pick(obj,['a', 'c']) returns {a: 1, c: 3}
+ */
 export const pick = <T>(object: { [key: string]: T }, keys: Array<string>): { [key: string]: T } => {
 	return keys.reduce((obj: { [key: string]: T }, key: string) => {
 		if (object && Object.prototype.hasOwnProperty.call(object, key)) {
@@ -7,16 +23,46 @@ export const pick = <T>(object: { [key: string]: T }, keys: Array<string>): { [k
 	}, {});
 };
 
-export const mapValues = <T>(object: { [key: string]: T }, mapper: (key: T) => T): { [key: string]: T } => {
-	return Object.entries(object).reduce((ret: { [key: string]: T }, [key, obj]) => {
+/**
+ * This function returns an object where a function mapper is applied to get value of the input object.
+ *
+ * @param object:  An object in the form { [key: string]: T }
+ * @param mapper: A function to be applied to each value in object.
+ * @returns an object with the same keys as the input object and where mapper has been applied to each value.
+ *
+ * const obj = { a: 1, b: 2, c: 3, d: 4 };
+ * mapValues(obj, (x: number) => x + 1) returns { a: 2, b: 3, c: 4, d: 5 }
+ *
+ *
+ */
+
+export const mapValues = <T, S>(object: { [key: string]: T }, mapper: (key: T) => S): { [key: string]: S} => {
+	return Object.entries(object).reduce((ret: { [key: string]: S }, [key, obj]) => {
 		ret[key] = mapper(obj);
 		return ret;
 	}, {});
 };
 
+/**
+ *  Inverts the input object's keys and values.
+ *
+ * @param object Object of the form: { [key: string]: string }
+ * @returns the object where the key and value has been swapped.
+ *
+ *
+ */
+
 export const invert = (object: { [key: string]: string }) => {
 	return Object.keys(object).reduce((acc, [key, value]) => ({ ...acc, [value]: key }), {});
 };
+
+/**
+ * This returns a object from the input object in which the keys satisfy the check condition.
+ *
+ * @param object  An object in the form { [key: string]: T }
+ * @param check A function where true values are to be in the return object.
+ * @returns an object on only the key/value pairs where check is true.
+ */
 
 export const pickBy = <T>(object: { [key: string]: T }, check: (value: T) => boolean) => {
 	const obj: { [key: string]: T } = {};

--- a/tests/unit-tests/utils.spec.ts
+++ b/tests/unit-tests/utils.spec.ts
@@ -1,0 +1,58 @@
+// This tests the lodash function replacments in /src/common/utils.ts
+
+import { pick, mapValues, invert, pickBy } from 'src/common/utils';
+
+test('testing pick', () => {
+	const obj = { a: 1, b: 2, c: 3, d: 4 };
+
+	expect(pick(obj, ['a', 'b', 'c', 'd'])).toStrictEqual(obj);
+	expect(pick(obj, ['a', 'c'])).toStrictEqual({ a: 1, c: 3 });
+	expect(pick(obj, ['a', 'b', 'd', 'e'])).toStrictEqual({ a: 1, b: 2, d: 4 });
+
+});
+
+test('testing mapValues', () => {
+	const obj = { a: 1, b: 2, c: 3, d: 4 };
+	expect(mapValues(obj, (x: number) => x + 1)).toStrictEqual({
+		a: 2, b: 3, c: 4, d: 5
+	});
+	expect(mapValues(obj, (x: number) => Math.pow(x, 2))).toStrictEqual({
+		a: 1, b: 4, c: 9, d: 16
+	});
+
+	const obj2 = {
+		apples: { category: 'produce', quantity: 3 },
+		hot_dots: { category: 'deli', quantity: 5 },
+		ice_cream: { category: 'frozen', quantity: 10 }
+	};
+
+	expect(mapValues(obj2, food => food.category)).toStrictEqual({
+		apples: 'produce',
+		hot_dots: 'deli',
+		ice_cream: 'frozen'
+	});
+
+});
+
+test('testing invert', () => {
+	const obj = { a: '1', b: '2', c: '3', d: '4' };
+	expect(invert(obj)).toStrictEqual({
+		'1': 'a', '2': 'b', '3': 'c', '4': 'd'
+	});
+});
+
+test('testing pickBy', () => {
+	const obj = { a: 1, b: '2', c: 3 };
+	expect(pickBy(obj, (v: number | string) => typeof v === 'number'))
+		.toStrictEqual({ a: 1, c: 3 });
+
+	const obj2 = {
+		key1: 'apple',
+		key2: 'banana',
+		key3: 'art history',
+	};
+
+	expect(pickBy(obj2, (v: string) => /^a/.test(v)))
+		.toStrictEqual({ key1: 'apple', key3: 'art history' });
+
+});

--- a/tests/unit-tests/utils.spec.ts
+++ b/tests/unit-tests/utils.spec.ts
@@ -1,6 +1,6 @@
 // This tests the lodash function replacments in /src/common/utils.ts
 
-import { pick, mapValues, invert, pickBy } from 'src/common/utils';
+import { pick, mapValues, invert, pickBy, random } from 'src/common/utils';
 
 test('testing pick', () => {
 	const obj = { a: 1, b: 2, c: 3, d: 4 };
@@ -54,5 +54,30 @@ test('testing pickBy', () => {
 
 	expect(pickBy(obj2, (v: string) => /^a/.test(v)))
 		.toStrictEqual({ key1: 'apple', key3: 'art history' });
+
+});
+
+test('testing random', () => {
+	// test 1000 random numbers between 5 and 10.
+	// should return numbers in 5,6,7,8,9
+	const arr = [];
+	for (let i = 0; i < 1000; i++) {
+		arr[i] = random(5, 10);
+	}
+
+	expect(arr.filter(v => v >= 5 && v <= 10).length).toBe(1000);
+	expect(arr.filter(v => v == 5).length).toBeGreaterThan(0);
+	expect(arr.filter(v => v == 10).length).toBe(0);
+
+	// test 1000 random numbers between 5.5 and 10.5.
+	// should returns numbers in 6,7,8,9 only.
+	const arr2 = [];
+	for (let i = 0; i < 100; i++) {
+		arr2[i] = random(5.5, 10.5);
+	}
+
+	expect(arr2.filter(v => v >= 5 && v <= 10).length).toBe(100);
+	expect(arr2.filter(v => v == 5).length).toBe(0);
+	expect(arr2.filter(v => v == 10).length).toBe(0);
 
 });


### PR DESCRIPTION
This adds documentation and tests to the functions in `src/common/utils.ts`, which are replacements for lodash functions. 

Note: I also changed the signature of `mapValues` to allow the return type of the object to differ from the input object. 